### PR TITLE
Update syntax highlighting to handle line numbers

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -96,6 +96,20 @@ posts_limit: 3 # The number of posts to show in home
 paginate: 6 # The number of posts to show per page of pagination of blog posts
 paginate_path: "/assets/blog/page:num"
 
+markdown: kramdown
+highlighter: rouge
+# kramdown:
+#   input: GFM
+#   syntax_highlighter: rouge
+#   syntax_highlighter_opts: # Rouge Options › https://github.com/jneen/rouge#full-options
+#     css_class: highlight
+#     # default_lang: console
+#     span:
+#       line_numbers: false
+#     block:
+#       line_numbers: true
+#       start_line: 1
+
 # ============= general settings for the theme ===============
 plugins:
   - jekyll-github-metadata
@@ -126,5 +140,3 @@ exclude:
   - .deprecated
   - .github
   - "*.gem"
-
-markdown: kramdown

--- a/_posts/2019-01-29-syntax-highlighter.md
+++ b/_posts/2019-01-29-syntax-highlighter.md
@@ -98,3 +98,20 @@ import sys
 def my_function():
   print("Hello from a function")
 ```
+
+## Using liquid
+
+### Without line numbers
+
+{% highlight javascript %}
+function some(code) { /*goes here*/ }
+let x = 21;
+{% endhighlight %}
+
+
+### With line numbers
+
+{% highlight javascript linenos %}
+function some(code) { /*goes here*/ }
+let x = 21;
+{% endhighlight %}

--- a/_sass/_highlight-syntax.scss
+++ b/_sass/_highlight-syntax.scss
@@ -1,4 +1,4 @@
-.highlight  { width: 100%; overflow: auto; background-color: var(--color-canvas-inset) !important; padding: 8px; }
+.highlight  { overflow: auto; background-color: var(--color-canvas-inset) !important; padding: 8px; }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
 .highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
 .highlight .k { font-weight: bold } /* Keyword */
@@ -64,3 +64,33 @@
 .highlight .lineno {-webkit-user-select: none;-moz-user-select: none; -o-user-select: none;}
 .lineno::-moz-selection {background-color: transparent;} /* Mozilla specific */
 .lineno::selection {background-color: transparent;} /* Other major browsers */
+.lineno { opacity: 0.5;}
+
+.highlight table {
+    margin: inherit;
+}
+
+.highlight table tr {
+    background-color: inherit;
+    border-top: inherit;
+}
+
+.highlight table td {
+    padding: inherit;
+    border: inherit;
+}
+
+.highlight pre {
+    background-color: inherit !important;
+    border-radius: 0px !important;
+}
+
+.highlight code pre {
+    padding: 0px !important;
+    background-color: inherit;
+}
+
+.highlight code .gutter,
+.highlight code .rouge-gutter {
+    padding-right: 16px !important;
+}


### PR DESCRIPTION
Adds styling for code with line numbers

![syntax-lineno](https://github.com/athackst/jekyll-theme-profile/assets/6098197/5fb30fd9-b75f-4dc1-8706-fc691217adf7)

Closes #58 