### PR TITLE
Standardize theme toggle placement across all styles

### DIFF
--- a/_includes/toggle.html
+++ b/_includes/toggle.html
@@ -1,4 +1,4 @@
 <div class="d-flex flex-items-center">
-    <button id="theme-toggle" class="btn btn-sm mr-2 tooltipped tooltipped-se" aria-label="Color mode" type="button"><span id="theme-icon"
+    <button id="theme-toggle" class="btn btn-octicon mr-2 tooltipped tooltipped-se" aria-label="Color mode" type="button"><span id="theme-icon"
             class="octicon octicon-moon-24"></span></button>
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,11 +16,7 @@
 <body class="min-height-full">
     {%- if style == 'stacked' %}
     <div class="container-lg min-height-full">
-
         <div class="Profile text-center">
-            <div class="d-flex flex-justify-end pt-3">
-                {%- include toggle.html %}
-            </div>
             {%- include masthead.html metadata=metadata %}
             {%- if site.repo_info %}
             <div class="py-2">
@@ -39,13 +35,16 @@
             {%- endif %}
         </div>
         <div class="color-bg-default">
-            {%- if breadcrumbs %}
-            <div class="p-3">
+            <div class="d-flex p-2">
+                {%- if breadcrumbs %}
                 {%- include breadcrumbs.html %}
+                {%- endif %}
+                <div class="flex-1">
+                </div>
+                {% include toggle.html %}
             </div>
-            {%- endif %}
             <div class="p-responsive markdown-body ">
-            {{ content }}
+                {{ content }}
             </div>
         </div>
     </div>
@@ -105,9 +104,6 @@
                     {% include mini-repo-info-card.html class="Header-link" %}
                 </div>
                 {% endif %}
-                <div class="Header-item mr-3">
-                {% include toggle.html %}
-                </div>
                 <div class="Header-item mr-0">
                     <a href="https://github.com/{{ user.login }}" class="Header-link d-flex flex-items-center">
                         <img class="avatar img-cover" height="32" width="32" alt="{{ name }}"
@@ -125,9 +121,14 @@
         </div>
     </div>
     <div class="container-xl p-3 color-bg-default flex-1">
-        {%- if breadcrumbs %}
-        {%- include breadcrumbs.html %}
-        {%- endif %}
+        <div class="d-flex pb-2">
+            {%- if breadcrumbs %}
+            {%- include breadcrumbs.html %}
+            {%- endif %}
+            <div class="flex-1">
+            </div>
+            {% include toggle.html %}
+        </div>
         <div class="p-responsive markdown-body">
             {{ content }}
         </div>


### PR DESCRIPTION
Toggle placement is now always on the upper right corner of the content

Topbar
![image](https://github.com/athackst/jekyll-theme-profile/assets/6098197/0cd443c6-2adc-4031-a853-6769119d74dc)


Sidebar
![image](https://github.com/athackst/jekyll-theme-profile/assets/6098197/66e09f84-1df9-4b9d-9313-9fad6be9602b)


Stacked
![image](https://github.com/athackst/jekyll-theme-profile/assets/6098197/194d8783-ae44-4fd5-a9bd-37d7e4c46b63)
