### PR TITLE
Use  image tag instead of social_image for SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ user_image: /media/user-image.jpg
 
 ####################
 # Social media
-# social_image: /screenshot.png # The social media thumbnail image to use in post links.
 # icon_color: "#959da5" # The color of the social media icons on the site
 # social_media: # Your social media accounts
   # behance: your_username
@@ -362,10 +361,24 @@ repositories:
 You can set the social media image for your site with the setting
 
 ```yaml
-social_image: /screenshot.jpg
+image: /screenshot.jpg
 ```
 
 This works on both yaml frontmatter for a page and in the `_config.yml` file.  Page settings will override site settings.
+
+Set the default for posts through the default settings in the `_config.yml` file.
+
+```yaml
+defaults:
+  - scope:
+      path: "" # an empty string here means all files in the project
+      type: "posts"
+    values:
+      layout: "post"
+      permalink: /blog/:year/:month/:day/:title.html
+      image: /assets/img/default.png # The default image used for social and posts.
+      toc: true
+```
 
 #### Adding your socials
 

--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,6 @@ profile_link: true # Show a link to the github profile for the user
 
 ####################
 # Social media
-social_image: /screenshot.png # The social media thumbnail image to use in post links.
 # icon_color: "#959da5" # The color of the social media icons on the site
 # social_media: # Your social media accounts
 #   behance: your_username
@@ -106,10 +105,8 @@ repositories:
 ####################
 # Blog
 posts_limit: 3 # The number of posts to show in home
-
 paginate: 6 # The number of posts to show per page of pagination of blog posts
 paginate_path: "/assets/blog/page:num"
-
 markdown: kramdown
 highlighter: rouge
 # kramdown:
@@ -140,7 +137,7 @@ defaults:
     values:
       layout: "post"
       permalink: /blog/:year/:month/:day/:title.html
-      image: /assets/img/default.png
+      image: /assets/img/default.png # The default image used for social and posts.
       toc: true
 
 exclude:

--- a/_includes/post-card.html
+++ b/_includes/post-card.html
@@ -1,10 +1,9 @@
 {%- assign icon = post.type | default: "comment" %}
-{%- assign image = post.image | default: post.social_image | default: "assets/img/default.png" %}
 <div class="col-sm-6 col-lg-4 ">
   <div class="py-4 d-flex flex-column border-top">
     <div class="image-container">
       <a href="{{ post.url | relative_url }}">
-        <img class="rounded-2" src="{{ image | relative_url }}" width="377" height="200" alt="{{ post.title }}">
+        <img class="rounded-2" src="{{ post.image | relative_url }}" width="377" height="200" alt="{{ post.title }}">
       </a>
     </div>
     <h3 class="h6-mktg mb-12px">

--- a/_includes/post-feature-card.html
+++ b/_includes/post-feature-card.html
@@ -1,10 +1,9 @@
 {%- assign icon = post.type | default: "comment" %}
-{%- assign image = post.image | default: post.social_image | default: "assets/img/default.png" %}
 <div class="py-4 d-flex flex-column flex-md-row flex-md-row-reverse p-responsive">
   <div class="col-12 col-lg-8 p-responsive">
     <div class="image-container">
       <a href="{{ post.url | relative_url }}">
-        <img class="rounded-2" src="{{ image | relative_url }}" width="800" height="425" alt="{{ post.title }}">
+        <img class="rounded-2" src="{{ post.image | relative_url }}" width="800" height="425" alt="{{ post.title }}">
       </a>
     </div>
   </div>

--- a/_includes/post-timeline-card.html
+++ b/_includes/post-timeline-card.html
@@ -1,6 +1,4 @@
 {%- assign icon = post.type | default: "comment" %}
-{%- assign image = post.image | default: post.social_image %}
-{%- assign video = post.video %}
 <div class="TimelineItem flex-wrap">
   <div class="col-12 col-md-5 position-relative">
     <div class="TimelineItem-title mt-5 position-sticky d-flex">
@@ -23,13 +21,13 @@
   </div>
   <div class="col-12 col-md-7">
     <div class="ml-5 mt-5">
-      {%- if image %}
+      {%- if post.image %}
       <div class="image-container mb-5">
-        <img class="rounded-2" src="{{ image}}" width="800" height="425" alt="{{ post.title }}" />
+        <img class="rounded-2" src="{{ post.image}}" width="800" height="425" alt="{{ post.title }}" />
       </div>
       {%- endif %}
-      {%- if video %}
-      <iframe width="560" height="315" src="{{ page.video }}" frameborder="0" gesture="media"
+      {%- if post.video %}
+      <iframe width="560" height="315" src="{{ post.video }}" frameborder="0" gesture="media"
         allow="encrypted-media; fullscreen; picture-in-picture" allowfullscreen></iframe>
       {%- endif %}
       <div class="summary"> {{ post.excerpt }}</div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,7 +1,6 @@
 ---
 layout: default
 ---
-{%- assign image = page.image | default: page.social_image | default: "assets/img/default.png" %}
 {%- assign user = site.github.owner %}
 {%- assign name = page.author | default: user.name | default: user.login %}
 
@@ -15,7 +14,7 @@ layout: default
             <div class="offset-lg-1 col-lg-10">
                 <div class="position-relative z-1">
                     <div class="image-container">
-                        <img src="{{ image | relative_url }}" class="cover-image rounded-2" alt="{{ page.title }}"/>
+                        <img src="{{ page.image | relative_url }}" class="cover-image rounded-2" alt="{{ page.title }}"/>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Since Jekyll SEO uses the `image` tag, remove the redundant social_image